### PR TITLE
Add aggregrate alias to documentation

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -394,6 +394,7 @@ normalizeToDuration <- function(x) {
 #'
 #' @importFrom stats aggregate
 #'
+#' @aliases aggregate
 #' @export
 aggregate.tracks <- function( x, measure, by="subtracks", FUN=mean,
     subtrack.length=seq(1, (maxTrackLength(x)-1)),

--- a/man/aggregate.tracks.Rd
+++ b/man/aggregate.tracks.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/functions.R
 \name{aggregate.tracks}
 \alias{aggregate.tracks}
+\alias{aggregate}
 \title{Compute Summary Statistics of Subtracks}
 \usage{
 \method{aggregate}{tracks}(x, measure, by = "subtracks", FUN = mean,


### PR DESCRIPTION
This makes sure that the documentation is included when you do `?aggregate` (which is very useful for students who don't really understand S3methods and hence can't find the help file ;) ):
![image](https://user-images.githubusercontent.com/907362/101920550-3c8a5d00-3bcc-11eb-947b-3e6319abd829.png)

